### PR TITLE
Move response caching into Europeana::API::Requestable

### DIFF
--- a/lib/europeana/api/record/hierarchy.rb
+++ b/lib/europeana/api/record/hierarchy.rb
@@ -11,7 +11,6 @@ module Europeana
         autoload :Parent, 'europeana/api/record/hierarchy/parent'
         autoload :PrecedingSiblings, 'europeana/api/record/hierarchy/preceding_siblings'
         autoload :Self, 'europeana/api/record/hierarchy/self'
-        # etc
 
         def initialize(id)
           @id = id

--- a/lib/europeana/api/request.rb
+++ b/lib/europeana/api/request.rb
@@ -21,37 +21,25 @@ module Europeana
 
       # @return (see Net::HTTP#request)
       def execute
-        cached do
-          http = Net::HTTP.new(uri.host, uri.port)
-          request = Net::HTTP::Get.new(uri.request_uri)
-          retries = Europeana::API.max_retries
+        http = Net::HTTP.new(uri.host, uri.port)
+        request = Net::HTTP::Get.new(uri.request_uri)
+        retries = Europeana::API.max_retries
 
-          begin
-            attempt = Europeana::API.max_retries - retries + 1
-            logger.info("[Europeana::API] Request URL: #{uri}")
-            benchmark("[Europeana::API] Request query (attempt ##{attempt})", level: :info) do
-              @response = http.request(request)
-            end
-          rescue Timeout::Error, Errno::ECONNREFUSED, EOFError
-            retries -= 1
-            raise unless retries > 0
-            logger.warn("[Europeana::API] Network error; sleeping #{Europeana::API.retry_delay}s")
-            sleep Europeana::API.retry_delay
-            retry
+        begin
+          attempt = Europeana::API.max_retries - retries + 1
+          logger.info("[Europeana::API] Request URL: #{uri}")
+          benchmark("[Europeana::API] Request query (attempt ##{attempt})", level: :info) do
+            @response = http.request(request)
           end
-
-          @response
+        rescue Timeout::Error, Errno::ECONNREFUSED, EOFError
+          retries -= 1
+          raise unless retries > 0
+          logger.warn("[Europeana::API] Network error; sleeping #{Europeana::API.retry_delay}s")
+          sleep Europeana::API.retry_delay
+          retry
         end
-      end
 
-      def cache_key
-        "Europeana/API/#{uri}"
-      end
-
-      def cached
-        Europeana::API.cache_store.fetch(cache_key, expires_in: Europeana::API.cache_expires_in) do
-          yield
-        end
+        @response
       end
 
       def logger

--- a/spec/europeana/api/record/hierarchy_spec.rb
+++ b/spec/europeana/api/record/hierarchy_spec.rb
@@ -2,27 +2,13 @@ RSpec.describe Europeana::API::Record::Hierarchy do
   let(:record_id) { '/abc/1234' }
   let(:params) { { callback: 'doSomething();' } }
 
-  context 'when initialized with record ID' do
-    subject { described_class.new(record_id) }
+  subject { described_class.new(record_id) }
 
-    it { is_expected.to be_a(HashWithIndifferentAccess) }
-    it { is_expected.to respond_to(:execute_request) }
-
-    it 'should retrieve self hierarchy data from the API' do
-      subject
-      expect(a_request(:get, %r{www.europeana.eu/api/v2/record#{record_id}/self.json})).to have_been_made.once
-    end
-
-    describe '#request_url' do
-      it 'should default relation to self' do
-        expect(subject.request_url).to match(%r{/record#{record_id}/self.json})
-      end
-    end
-
-    describe '#[]' do
-      it 'should be the content of the API self response' do
-        expect(subject).not_to have_key(:self)
-        expect(subject).to have_key(:id)
+  %w(self parent children).each do |relation|
+    describe "##{relation}" do
+      it "should retrieve #{relation} hierarchy data from the API" do
+        subject.send(relation)
+        expect(a_request(:get, %r{www.europeana.eu/api/v2/record#{record_id}/#{relation}.json})).to have_been_made.once
       end
     end
   end

--- a/spec/europeana/api/record_spec.rb
+++ b/spec/europeana/api/record_spec.rb
@@ -129,12 +129,5 @@ RSpec.describe Europeana::API::Record do
     let(:record) { described_class.new(record_id, params) }
     subject { record.hierarchy }
     it { is_expected.to be_a(Europeana::API::Record::Hierarchy) }
-    it 'should have assigned record attr' do
-      expect(subject.record_id).to eq(record_id)
-    end
-    it 'should fetch record hierarchy' do
-      subject
-      expect(a_request(:get, %r{www.europeana.eu/api/v2/record#{record_id}/self.json})).to have_been_made.once
-    end
   end
 end

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -4,5 +4,11 @@ RSpec.configure do |config|
 
     stub_request(:get, %r{www.europeana.eu/api/v2/record/[^/]+/[^/]+/self\.json}).
       to_return(body: lambda { |_| '{"success":true, "self":{"id":"' + record_id + '", "childrenCount":0, "hasChildren":false}}' })
+
+    stub_request(:get, %r{www.europeana.eu/api/v2/record/[^/]+/[^/]+/parent\.json}).
+      to_return(body: lambda { |_| '{"success":true, "self":{"id":"' + record_id + '", "childrenCount":5, "hasChildren":false}, "parent":{}}' })
+
+    stub_request(:get, %r{www.europeana.eu/api/v2/record/[^/]+/[^/]+/children\.json}).
+      to_return(body: lambda { |_| '{"success":true, "self":{"id":"' + record_id + '", "childrenCount":5, "hasChildren":false}, "children":[]}' })
   end
 end


### PR DESCRIPTION
... and prevent responses with errors from being cached.