### PR TITLE
set timout limit, remove retries on timeouts

### DIFF
--- a/europeana-api.gemspec
+++ b/europeana-api.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_dependency 'activesupport', '>= 4.2', '< 6.0'
+  # Locked to < v0.12.2 due to incompatibility with v0.12.2
+  # TODO: resolve incompatibility and unlock
   spec.add_dependency 'faraday', '~> 0.9', '< 0.12.2'
   spec.add_dependency 'faraday_middleware'
   spec.add_dependency 'multi_json', '~> 1.0'

--- a/europeana-api.gemspec
+++ b/europeana-api.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_dependency 'activesupport', '>= 4.2', '< 6.0'
-  spec.add_dependency 'faraday', '~> 0.9'
+  spec.add_dependency 'faraday', '~> 0.9', '< 0.12.2'
   spec.add_dependency 'faraday_middleware'
   spec.add_dependency 'multi_json', '~> 1.0'
   spec.add_dependency 'rack', '> 1.6.2'

--- a/lib/europeana/api/client.rb
+++ b/lib/europeana/api/client.rb
@@ -33,8 +33,8 @@ module Europeana
             conn.request :instrumentation
             conn.request :parameter_repetition
             conn.request :authenticated_request
-            conn.request :retry, max: 5, interval: 3,
-                                 exceptions: [Errno::ECONNREFUSED, EOFError]
+            conn.request :retry, max: 5, interval: 3, exceptions: [Errno::ECONNREFUSED, EOFError]
+
             conn.options.open_timeout = 5
             conn.options.timeout = 45
 

--- a/lib/europeana/api/client.rb
+++ b/lib/europeana/api/client.rb
@@ -34,8 +34,8 @@ module Europeana
             conn.request :parameter_repetition
             conn.request :authenticated_request
             conn.request :retry, max: 5, interval: 3,
-                                 exceptions: [Errno::ECONNREFUSED, Errno::ETIMEDOUT, 'Timeout::Error',
-                                              Faraday::Error::TimeoutError, EOFError]
+                                 exceptions: [Errno::ECONNREFUSED, Errno::ETIMEDOUT, 'Timeout::Error', EOFError]
+            conn.options.timeout = 45
 
             conn.response :json_various, content_type: /\bjson$/
             conn.response :text, content_type: %r{^text(\b[^/]+)?/(plain|html)$}

--- a/lib/europeana/api/client.rb
+++ b/lib/europeana/api/client.rb
@@ -34,7 +34,8 @@ module Europeana
             conn.request :parameter_repetition
             conn.request :authenticated_request
             conn.request :retry, max: 5, interval: 3,
-                                 exceptions: [Errno::ECONNREFUSED, Errno::ETIMEDOUT, 'Timeout::Error', EOFError]
+                                 exceptions: [Errno::ECONNREFUSED, EOFError]
+            conn.options.open_timeout = 5
             conn.options.timeout = 45
 
             conn.response :json_various, content_type: /\bjson$/


### PR DESCRIPTION
To handle timeouts better, set the timeout limit to 45 seconds and then don't cause a retry.