### PR TITLE
Record API LangMaps

### DIFF
--- a/europeana-api.gemspec
+++ b/europeana-api.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   # TODO: resolve incompatibility and unlock
   spec.add_dependency 'faraday', '~> 0.9', '< 0.12.2'
   spec.add_dependency 'faraday_middleware'
+  spec.add_dependency 'iso-639', '~> 0.2.5'
   spec.add_dependency 'multi_json', '~> 1.0'
   spec.add_dependency 'rack', '> 1.6.2'
   spec.add_dependency 'typhoeus', '~> 1.1'

--- a/lib/europeana/api/record.rb
+++ b/lib/europeana/api/record.rb
@@ -8,6 +8,8 @@ module Europeana
     class Record
       include Resource
 
+      autoload :LangMap, 'europeana/api/record/lang_map'
+
       has_api_endpoint :search,
                        path: '/v2/search.json',
                        errors: {

--- a/lib/europeana/api/record/lang_map.rb
+++ b/lib/europeana/api/record/lang_map.rb
@@ -19,11 +19,23 @@ module Europeana
         NON_ISO_LANG_CODES = ['def', '']
 
         class << self
-          def lang_map?(obj)
-            return false unless obj.is_a?(Hash)
-            obj.keys.map(&:to_s).all? { |key| known_lang_map_key?(key) }
+          # Is the argument a language map?
+          #
+          # Critera:
+          # * Must be a +Hash+.
+          # * Must have only keys which are known language codes
+          #
+          # @param candidate [Object] Object to check
+          # @return [Boolean]
+          def lang_map?(candidate)
+            return false unless candidate.is_a?(Hash)
+            candidate.keys.map(&:to_s).all? { |key| known_lang_map_key?(key) }
           end
 
+          # Is the argument a known language map key?
+          #
+          # @param key [String] String to check
+          # @return [Boolean]
           def known_lang_map_key?(key)
             key = key.dup.downcase
             DEPRECATED_ISO_LANG_CODES.include?(key) ||
@@ -31,9 +43,22 @@ module Europeana
               !ISO_639.find(key.split('-').first).nil?
           end
 
-          def localize_lang_map(lang_map)
+          # Localise a language map
+          #
+          # 1. If the argument is not a language map, return as-is
+          # 2. If the language map has a key for the current locale, return that
+          #    value
+          # 3. If the language map has a key for the default locale, return that
+          #    value
+          # 4. Else, return all values
+          #
+          # Arrays will be recursed over, localising each element.
+          #
+          # @param lang_map [Object] Object to attempt to localise
+          # @return [Array<Object>] Localised value
+          def localise_lang_map(lang_map)
             if lang_map.is_a?(Array)
-              return lang_map.map { |l| localize_lang_map(l) }
+              return lang_map.map { |val| localise_lang_map(val) }
             end
 
             return lang_map unless lang_map?(lang_map)
@@ -43,27 +68,16 @@ module Europeana
               lang_map.values
           end
 
+          # Fetch the language map value for a given locale
+          #
+          # @param lang_map [Hash] Verified language map
+          # @param locale [String] Locale to fetch the value for
+          # @return [Array<Object>,nil] Array of value(s) for the given locale,
+          #   or nil if none are present
           def lang_map_value(lang_map, locale)
             keys = salient_lang_map_keys(lang_map, locale)
             return nil unless keys.present?
             keys.map { |k| lang_map[k] }.flatten.uniq
-          end
-
-          def dereferenced_lang_map_value(value)
-            return nil if value.nil?
-
-            if value.is_a?(Array)
-              return value.map { |v| dereferenced_lang_map_value(v) }
-            end
-
-            return value unless value.is_a?(String)
-
-            concept = root.fetch('concepts', []).detect { |c| c[:about] == value }
-            if concept.present? && concept.key?(:prefLabel)
-              localize_lang_map(concept[:prefLabel])
-            else
-              return value
-            end
           end
 
           protected

--- a/lib/europeana/api/record/lang_map.rb
+++ b/lib/europeana/api/record/lang_map.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'iso-639'
+
+module Europeana
+  module API
+    class Record
+      ##
+      # Methods for working with "LangMap" data types in Record API JSON responses
+      #
+      # @see https://pro.europeana.eu/resources/apis/search#json-langmap
+      module LangMap
+        # @see https://www.loc.gov/standards/iso639-2/php/code_changes.php
+        DEPRECATED_ISO_LANG_CODES = %w(in iw jaw ji jw mo mol scc scr sh)
+
+        # Special keys API may return in a LangMap, not ISO codes
+        # TODO: Empty key acceptance is a workaround for malformed API data
+        #   output; remove when fixed at source
+        NON_ISO_LANG_CODES = ['def', '']
+
+        class << self
+          def lang_map?(obj)
+            return false unless obj.is_a?(Hash)
+            obj.keys.map(&:to_s).all? { |key| known_lang_map_key?(key) }
+          end
+
+          def known_lang_map_key?(key)
+            key = key.dup.downcase
+            DEPRECATED_ISO_LANG_CODES.include?(key) ||
+              NON_ISO_LANG_CODES.include?(key) ||
+              !ISO_639.find(key.split('-').first).nil?
+          end
+
+          def localize_lang_map(lang_map)
+            if lang_map.is_a?(Array)
+              return lang_map.map { |l| localize_lang_map(l) }
+            end
+
+            return lang_map unless lang_map?(lang_map)
+
+            lang_map_value(lang_map, ::I18n.locale.to_s) ||
+              lang_map_value(lang_map, ::I18n.default_locale.to_s) ||
+              lang_map.values
+          end
+
+          def lang_map_value(lang_map, locale)
+            keys = salient_lang_map_keys(lang_map, locale)
+            return nil unless keys.present?
+            keys.map { |k| lang_map[k] }.flatten.uniq
+          end
+
+          def dereferenced_lang_map_value(value)
+            return nil if value.nil?
+
+            if value.is_a?(Array)
+              return value.map { |v| dereferenced_lang_map_value(v) }
+            end
+
+            return value unless value.is_a?(String)
+
+            concept = root.fetch('concepts', []).detect { |c| c[:about] == value }
+            if concept.present? && concept.key?(:prefLabel)
+              localize_lang_map(concept[:prefLabel])
+            else
+              return value
+            end
+          end
+
+          protected
+
+          def salient_lang_map_keys(lang_map, locale)
+            iso_code = locale.split('-').first
+            iso_locale = ISO_639.find(iso_code)
+
+            # Favour exact matches
+            keys = lang_map.keys.select do |k|
+              [locale, iso_locale.alpha2, iso_locale.alpha3].include?(k)
+            end.flatten.compact
+            return keys unless keys.blank?
+
+            # Any sub-code will do
+            lang_map.keys.select do |k|
+              k =~ %r{\A#{iso_code}-}
+            end.flatten.compact
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/europeana/api/record/lang_map_spec.rb
+++ b/spec/europeana/api/record/lang_map_spec.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 RSpec.describe Europeana::API::Record::LangMap do
+  before do
+    I18n.config.available_locales = %i(de en fr nl)
+  end
+  let(:lang_map_hash) do
+    { 'en' => 'this', 'fr' => 'ce' }
+  end
+  let(:non_lang_map_hash) do
+    { 'first' => 'this', 'then' => 'that' }
+  end
+
   describe '.lang_map?' do
     subject { described_class.lang_map?(var) }
 
@@ -11,13 +21,75 @@ RSpec.describe Europeana::API::Record::LangMap do
 
     context 'when a Hash' do
       context 'with non-language code keys' do
-        let(:var) { { 'first' => 'this', 'then' => 'that' } }
+        let(:var) { non_lang_map_hash }
         it { is_expected.to be false }
       end
 
       context 'with language code keys' do
-        let(:var) { { 'en' => 'this', 'fr' => 'ce' } }
+        let(:var) { lang_map_hash }
         it { is_expected.to be true }
+      end
+    end
+  end
+
+  describe '.localise_lang_map' do
+    subject { described_class.localise_lang_map(var) }
+
+    context 'when an Array' do
+      let(:var) { [lang_map_hash, lang_map_hash] }
+      before do
+        I18n.locale = :fr
+      end
+
+      it 'localises each element' do
+        expect(subject).to eq([[lang_map_hash['fr']], [lang_map_hash['fr']]])
+      end
+    end
+
+    context 'when not an Array' do
+      context 'when a language map' do
+        let(:var) { lang_map_hash }
+        context 'when current locale is present' do
+          before do
+            I18n.locale = :fr
+          end
+
+          it 'is returned in array' do
+            expect(subject).to eq([var['fr']])
+          end
+        end
+
+        context 'when current locale is not present' do
+          before do
+            I18n.locale = :de
+          end
+
+          context 'when default locale is present' do
+            before do
+              I18n.default_locale = :en
+            end
+
+            it 'is returned in array' do
+              expect(subject).to eq([var['en']])
+            end
+          end
+
+          context 'when default locale is not present' do
+            before do
+              I18n.default_locale = :nl
+            end
+            it 'returns all values' do
+              expect(subject).to eq(var.values)
+            end
+          end
+        end
+      end
+
+      context 'when not a language map' do
+        let(:var) { non_lang_map_hash }
+        it 'returns the argument' do
+          expect(subject).to eq(var)
+        end
       end
     end
   end

--- a/spec/europeana/api/record/lang_map_spec.rb
+++ b/spec/europeana/api/record/lang_map_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe Europeana::API::Record::LangMap do
+  describe '.lang_map?' do
+    subject { described_class.lang_map?(var) }
+
+    context 'when not a Hash' do
+      let(:var) { [] }
+      it { is_expected.to be false }
+    end
+
+    context 'when a Hash' do
+      context 'with non-language code keys' do
+        let(:var) { { 'first' => 'this', 'then' => 'that' } }
+        it { is_expected.to be false }
+      end
+
+      context 'with language code keys' do
+        let(:var) { { 'en' => 'this', 'fr' => 'ce' } }
+        it { is_expected.to be true }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a helper module with methods for working with "LangMap" data types in Record API JSON responses.

See: https://pro.europeana.eu/resources/apis/search#json-langmap